### PR TITLE
Ninalopatina add file type support

### DIFF
--- a/backend/danswer/file_processing/extract_file_text.py
+++ b/backend/danswer/file_processing/extract_file_text.py
@@ -27,7 +27,6 @@ from unstructured.staging.base import dict_to_elements
 
 logger = setup_logger()
 
-
 TEXT_SECTION_SEPARATOR = "\n\n"
 
 
@@ -43,6 +42,8 @@ PLAIN_TEXT_FILE_EXTENSIONS = [
     ".xml",
     ".yml",
     ".yaml",
+    ".rst",
+    ".org",
 ]
 
 
@@ -54,6 +55,18 @@ VALID_FILE_EXTENSIONS = PLAIN_TEXT_FILE_EXTENSIONS + [
     ".eml",
     ".epub",
     ".html",
+    ".bmp",
+    ".doc",
+    ".heic",
+    ".jpeg",
+    ".png",
+    ".msg",
+    ".odt",
+    ".p7s",
+    ".ppt",
+    ".rtf",
+    ".tiff",
+    ".xls",
 ]
 
 def _sdk_partition_request(file: IO[Any], file_name: str, **kwargs) -> operations.PartitionRequest:


### PR DESCRIPTION
## Description
Adds support for:
.bmp
.doc
.heic
.jpeg
.msg
.odt
.org
.p7s
.ppt
.rst
.rtf
.tiff
.xls


## How Has This Been Tested?
I ran this locally and successfully parsed my excel doc from before, as well as a table in a .jpeg 


## Accepted Risk
still have a bug in processing sheets that I'm unclear of the origin of


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [x ] All of the automated tests pass
- [ x] All PR comments are addressed and marked resolved
- [x ] If there are migrations, they have been rebased to latest main
- [x ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
^ only docker
- [x ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [x ] Docker images build and basic functionalities work
- [ x] Author has done a final read through of the PR right before merge
